### PR TITLE
Fixed overflow in ds_rename_handle

### DIFF
--- a/main.c
+++ b/main.c
@@ -16,15 +16,15 @@ ds_rename_handle(
 )
 {
 	// set our FileNameLength and FileName to DS_STREAM_RENAME
-	LPWSTR lpwStream = DS_STREAM_RENAME;
-	int rename_info_size = sizeof(FILE_RENAME_INFO) + sizeof(lpwStream) - 1;
+	int rename_info_size = sizeof(FILE_RENAME_INFO) + sizeof(DS_STREAM_RENAME) - 1;
 
 	PFILE_RENAME_INFO fRename = (PFILE_RENAME_INFO)malloc(rename_info_size);
 	if (!fRename)
 		return 0;
 
-	fRename->FileNameLength = sizeof(lpwStream);
-	RtlCopyMemory(fRename->FileName, lpwStream, sizeof(lpwStream));
+	LPWSTR lpwStream = DS_STREAM_RENAME;
+	fRename->FileNameLength = sizeof(DS_STREAM_RENAME);
+	RtlCopyMemory(fRename->FileName, lpwStream, sizeof(DS_STREAM_RENAME));
 
 	BOOL status = SetFileInformationByHandle(hHandle, FileRenameInfo, fRename, rename_info_size);
 	free(fRename);

--- a/main.c
+++ b/main.c
@@ -16,7 +16,7 @@ ds_rename_handle(
 )
 {
 	// set our FileNameLength and FileName to DS_STREAM_RENAME
-	int rename_info_size = sizeof(FILE_RENAME_INFO) + sizeof(DS_STREAM_RENAME) - 1;
+	int rename_info_size = sizeof(FILE_RENAME_INFO) + sizeof(DS_STREAM_RENAME) - sizeof(WCHAR); 
 
 	PFILE_RENAME_INFO fRename = (PFILE_RENAME_INFO)malloc(rename_info_size);
 	if (!fRename)

--- a/main.c
+++ b/main.c
@@ -15,15 +15,20 @@ ds_rename_handle(
 	HANDLE hHandle
 )
 {
-	FILE_RENAME_INFO fRename;
-	RtlSecureZeroMemory(&fRename, sizeof(fRename));
-
 	// set our FileNameLength and FileName to DS_STREAM_RENAME
 	LPWSTR lpwStream = DS_STREAM_RENAME;
-	fRename.FileNameLength = sizeof(lpwStream);
-	RtlCopyMemory(fRename.FileName, lpwStream, sizeof(lpwStream));
+	int rename_info_size = sizeof(FILE_RENAME_INFO) + sizeof(lpwStream) - 1;
 
-	return SetFileInformationByHandle(hHandle, FileRenameInfo, &fRename, sizeof(fRename) + sizeof(lpwStream));
+	PFILE_RENAME_INFO fRename = (PFILE_RENAME_INFO)malloc(rename_info_size);
+	if (!fRename)
+		return 0;
+
+	fRename->FileNameLength = sizeof(lpwStream);
+	RtlCopyMemory(fRename->FileName, lpwStream, sizeof(lpwStream));
+
+	BOOL status = SetFileInformationByHandle(hHandle, FileRenameInfo, fRename, rename_info_size);
+	free(fRename);
+	return status;
 }
 
 static


### PR DESCRIPTION
Added manual allocation of FILE_RENAME_INFO so that writing to FileName does not cause a stack overflow